### PR TITLE
componentes showcase: virtual-assistant => babcn

### DIFF
--- a/src/app/shared/components/showcase/component/tabs/tab-babcn-accordion.component.ts
+++ b/src/app/shared/components/showcase/component/tabs/tab-babcn-accordion.component.ts
@@ -29,7 +29,7 @@ export class TabBabcnAccordionComponent {
 
   showWord: string = "Hello!";
 
-  mainSelectorComponent: string = "virtual-assistant-accordion";
+  mainSelectorComponent: string = "babcn-accordion";
 
   case1: Code = {
     title: 'Case 1',

--- a/src/app/shared/components/showcase/component/tabs/tab-babcn-buttons-container.component.ts
+++ b/src/app/shared/components/showcase/component/tabs/tab-babcn-buttons-container.component.ts
@@ -46,7 +46,7 @@ export class TabBabcnButtonsContainerComponent {
 
   showWord: string = "Hello!";
 
-  mainSelectorComponent: string = "virtual-assistant-buttons-container";
+  mainSelectorComponent: string = "babcn-buttons-container";
 
   acommentComponent: string = `<!-- ${this.mainSelectorComponent.toUpperCase()} -->`;
 

--- a/src/app/shared/components/showcase/component/tabs/tab-babcn-container.component.ts
+++ b/src/app/shared/components/showcase/component/tabs/tab-babcn-container.component.ts
@@ -45,7 +45,7 @@ export class TabBabcnContainerComponent {
 
     showWord: string = "Hello!";
 
-    mainSelectorComponent: string = "virtual-assistant-container";
+    mainSelectorComponent: string = "babcn-container";
 
     case1: Code = {
         title: 'Case 1',

--- a/src/app/shared/components/showcase/component/tabs/tab-babcn-list.component.ts
+++ b/src/app/shared/components/showcase/component/tabs/tab-babcn-list.component.ts
@@ -45,7 +45,7 @@ export class TabBabcnListComponent {
 
     showWord: string = "Hello!";
 
-    mainSelectorComponent: string = "virtual-assistant-list";
+    mainSelectorComponent: string = "babcn-list";
 
     case1: Code = {
         title: 'Case 1',

--- a/src/app/shared/components/showcase/component/tabs/tab-babcn-tree.component.ts
+++ b/src/app/shared/components/showcase/component/tabs/tab-babcn-tree.component.ts
@@ -46,7 +46,7 @@ export class TabBabcnTreeComponent {
 
     showWord: string = "Hello!";
 
-    mainSelectorComponent: string = "virtual-assistant-tree";
+    mainSelectorComponent: string = "babcn-tree";
 
     case1: Code = {
         title: 'Case 1',


### PR DESCRIPTION
El componente que muestra el código y permite copiarlo al portapapeles todavía tenía el selector de la versión 1 ("virtual-assistant-xxx"). En la versión 2 usamos el prefijo "babcn-xxx".