### PR TITLE
correction links and logo

### DIFF
--- a/src/app/core/layout/header/header.component.html
+++ b/src/app/core/layout/header/header.component.html
@@ -4,7 +4,7 @@
 
     <!-- Title -->
 
-    <h1 class="padding-x" [@aniTitle] = 'title' (click)="toggleTitle()" routerLink="/">Business Assistant <span>BCN</span></h1>  
+    <h1 class="padding-x" [@aniTitle] = 'title'  routerLink="/">Business Assistant <span>BCN</span></h1>  
 
     <!-- Title -->
     

--- a/src/app/core/layout/header/header.component.ts
+++ b/src/app/core/layout/header/header.component.ts
@@ -54,8 +54,9 @@ export class HeaderComponent implements OnInit {
   }
 
   goToLink(num: number) {
-    if (num == 4) {
-      this.router.navigate(['login']);
-    }
+  console.log('should heading login component')
+
   }
+ 
+  
 }

--- a/src/app/features/home/components/header/header.component.html
+++ b/src/app/features/home/components/header/header.component.html
@@ -11,7 +11,7 @@
             <div class="button-header">
                 <button class="btn1 " 
                         mat-button 
-                        routerLink="virtual-assistant">
+                        routerLink="/">
                         {{'common.button.assistant' | translate | uppercase}}
                </button>
                         <button class="btn1" 

--- a/src/app/features/home/components/presentation/presentation.component.ts
+++ b/src/app/features/home/components/presentation/presentation.component.ts
@@ -50,7 +50,7 @@ ngOnInit(): void {
 
 
   onClickButtonVirtualAssistantButton = () => {
-    this.router.navigate(['virtual-assistant']);
+    console.log('should heading vistural assistance component');
   }
 
   onClickButtonMyEnvironment = () => {


### PR DESCRIPTION
Links with no active components were isolated
The main logo was redirected  to the home 