### PR TITLE
fixed footer.component scss exceeded budget

### DIFF
--- a/src/app/core/layout/footer/footer.component.scss
+++ b/src/app/core/layout/footer/footer.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../styles.scss';
+@import '../../../../styles/vars';
 
 *{
     background-color: black;

--- a/src/app/features/home/components/header/header.component.scss
+++ b/src/app/features/home/components/header/header.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../styles/global';
+@import '../../../../../styles/vars';
 
 .header{
     width: 100%;

--- a/src/app/features/users/components/login/login.component.scss
+++ b/src/app/features/users/components/login/login.component.scss
@@ -27,7 +27,7 @@ mat-form-field {
 
 .button-position {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
 }
 
 button {


### PR DESCRIPTION
#238 
Resolved exceeded budget for footer.component.scss
- imported "vars" stylesheet instead of "styles" stylesheet, because many elements of "styles" weren't used.

Optimized budget for header.component.scss
- imported "vars" stylesheet instead of "global" stylesheet, because many elements of "global" weren't used.

Minor scss change at login.component to resolve legacy warning at production build
