### PR TITLE
Feature/#274 : Mostrado de distritos

### DIFF
--- a/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/component/virtual-assistant-main-content.component.html
+++ b/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/component/virtual-assistant-main-content.component.html
@@ -1,7 +1,7 @@
 <!-- MAIN-CONTENT -->
 <section class="main">
     <div class="main-container">
-        
+
         <!-- babcn-TITLE -->
         <babcn-title titleInput='common.button.assistant'></babcn-title>
         <!-- END babcn-TITLE -->
@@ -28,18 +28,27 @@
             <mat-grid-tile>
 
                 <!-- babcn-BUTTONS-CONTAINER -->
-                <babcn-buttons-container containerHeight="395px" 
-                                         [containerWidth]='ratio.toString()' vaStyle="theme"
-                    [mainButtonVisibility]="!user"                      
-                    mainButtonText='common.button.save'
-                    mainButtonColor="primary" [mainButtonFunction]="onClickSaveButton"
-
-                    secondaryButtonText='common.button.see-summary' 
+                <babcn-buttons-container containerHeight="395px" [containerWidth]='ratio.toString()' vaStyle="theme"
+                    [mainButtonVisibility]="!user" mainButtonText='common.button.save' mainButtonColor="primary"
+                    [mainButtonFunction]="onClickSaveButton" secondaryButtonText='common.button.see-summary'
                     [secondaryButtonFunction]="onClickResumeButton">
 
                     <!-- babcn-LIST -->
                     <babcn-list [listDataInput]="dataShared"></babcn-list>
                     <!-- END babcn-LIST -->
+
+                    <!-- District-zones -->
+                    <div class="p-1 border" *ngIf="zonesList">
+                        <div *ngFor="let zone of zonesData">
+                                <div class="form-check">
+                                    <label class="form-check-label">
+                                        <mat-checkbox class="form-check-input"
+                                            (change)="checkZones(zone, $event.checked)">{{zone.zoneName}}
+                                        </mat-checkbox>
+                                    </label>
+                                </div>
+                        </div>
+                    </div>
 
                     <!-- babcn-TREE -->
                     <babcn-tree [treeDataInput]="dataSourceCategory"></babcn-tree>

--- a/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/component/virtual-assistant-main-content.component.spec.ts
+++ b/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/component/virtual-assistant-main-content.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VirtualAssistantMainContentComponent } from './virtual-assistant-main-content.component';
+
+describe('VirtualAssistantMainContentComponent', () => {
+  let component: VirtualAssistantMainContentComponent;
+  let fixture: ComponentFixture<VirtualAssistantMainContentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ VirtualAssistantMainContentComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(VirtualAssistantMainContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/component/virtual-assistant-main-content.component.spec.ts
+++ b/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/component/virtual-assistant-main-content.component.spec.ts
@@ -1,23 +1,81 @@
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { BreakpointService } from 'src/app/services/shared/breakpoint/breakpoint.service';
+import { of } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { VirtualAssistantMainContentComponent } from './virtual-assistant-main-content.component';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('VirtualAssistantMainContentComponent', () => {
-  let component: VirtualAssistantMainContentComponent;
-  let fixture: ComponentFixture<VirtualAssistantMainContentComponent>;
+
+    let component: VirtualAssistantMainContentComponent;
+    let fixture: ComponentFixture<VirtualAssistantMainContentComponent>;
+
+
+    const fakeBreakpointSrvMock = {
+        breakpoint$: of({} as any),
+        getCurrentScreenSize: jest.fn()
+      }
+    
+    const fakeDialogMock = {
+      open: jest.fn()
+    }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ VirtualAssistantMainContentComponent ]
-    })
-    .compileComponents();
-
+      imports: [
+        MatDialogModule,
+        HttpClientTestingModule
+      ],
+      providers: [
+          {provide: BreakpointService, useValue: fakeBreakpointSrvMock},
+          {provide: MatDialog, useValue: fakeDialogMock}
+      ],
+      schemas: [ NO_ERRORS_SCHEMA],
+      declarations: [
+        VirtualAssistantMainContentComponent,
+   
+      ],
+    }).compileComponents();
     fixture = TestBed.createComponent(VirtualAssistantMainContentComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
   });
 
-  it('should create', () => {
+  it('should create the app', () => {
+
     expect(component).toBeTruthy();
   });
+
+  it('getDataFromAccordian should update dataShared',() => {
+   
+    component.getDataFromAccordion(["sampleData"]);
+ 
+    expect(component.dataShared).toEqual(['sampleData']);
+  })
+
+  it('getDataFromAccordian should modify currentSelections',() => {
+   
+    component.getDataFromAccordion(["sampleData"]);
+ 
+    expect(component.dataShared).toEqual(['sampleData']);
+  })
+
+  it('Dialog should open upon clicking ResumeButton',() => {
+   
+    component.onClickResumeButton();
+
+    const spy = jest.spyOn(fakeDialogMock, 'open');
+    expect(spy).toHaveBeenCalled();
+  })
+
+  it('Dialog should open upon clicking SaveButton',() => {
+   
+    component.onClickSaveButton();
+
+    const spy = jest.spyOn(fakeDialogMock, 'open');
+    expect(spy).toHaveBeenCalled();
+  })
+
 });

--- a/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/component/virtual-assistant-main-content.component.ts
+++ b/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/component/virtual-assistant-main-content.component.ts
@@ -5,6 +5,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { BreakpointService } from 'src/app/services/shared/breakpoint/breakpoint.service';
 
+
 // VIRTUAL-ASSISTANT MODELS - BUSINESS ASISSTANT CATEGORY
 import { Category } from '../../../models/business-assistant.model';
 
@@ -15,6 +16,7 @@ import { VIRTUAL_ASSISTANT_MAT_GRID_LIST } from 'src/app/shared/components/compo
 
 // LOGIN MODAL COMPONENT 
 import { LoginModalComponent } from 'src/app/features/users/components/login-modal/login-modal.component';
+import { CommonService } from '../../../../../services/common/common.service';
 
 
 @Component({
@@ -34,10 +36,25 @@ export class VirtualAssistantMainContentComponent implements OnInit {
   // Data Shared with VirtualAssistantListComponent.
   dataShared: any[] = [] // TODO improve typing any[]
 
+  // Data Zones from common service
+  zonesData: any[] = [];
+
+  // Data Zones selected from 
+
+  zonesSelected: string[] = [];
+
+  // Show Zones List on right panel if user click on Zones button (accordion left)
+  zonesList: boolean = false;
+
+  // USER, wait for login implementation to verify the correct status.
+  user: boolean = false;
+
+
   // Not delete this empty constructor to make implementations easier to understand.
   constructor(
     public dialog: MatDialog,
-    private responsive: BreakpointService
+    private responsive: BreakpointService,
+    private zones: CommonService
   ) {
     const value = VIRTUAL_ASSISTANT_MAT_GRID_LIST.get(this.responsive.getCurrentScreenSize());
     if (value != undefined) {
@@ -58,11 +75,13 @@ export class VirtualAssistantMainContentComponent implements OnInit {
         }
       });
     });
+    // Get all Zones from common service
+    this.zones.getZones().subscribe((res) => {
+      this.zonesData = res.elements;
+    })
   }
 
 
-  // USER, wait for login implementation to verify the correct status.
-  user : boolean = false;
 
 
   /**
@@ -70,7 +89,15 @@ export class VirtualAssistantMainContentComponent implements OnInit {
    * @param accordionData The obtained data is shared by the component in the input of VirtualAssistantList.
    */
   getDataFromAccordion(accordionData: any[]) {  // TODO improve typing any[]
-    this.dataShared = [...accordionData];
+    this.dataShared = accordionData
+    this.showData(this.dataShared)
+  }
+
+  // Get data form accordion and show it in rigth side
+  showData(data: any[]) {
+    const isDataIncluded = data.indexOf('pages.business-assistant.section1.s1-item2');
+    this.zonesList = isDataIncluded == -1 ? this.zonesList : !this.zonesList;
+    console.log(this.zonesList);
   }
 
   /**
@@ -78,10 +105,12 @@ export class VirtualAssistantMainContentComponent implements OnInit {
    * It needs to be a callback function (it will be used as a parameter).
    */
   onClickResumeButton = (): void => {
+    
     this.dialog.open(ResumeDialogComponent, {
       // width: '500px', // sample use
       // height: '500px', // sample use
-      data: this.dataShared
+      data: this.dataShared.concat(this.zonesSelected),
+
     });
   }
 
@@ -90,9 +119,24 @@ export class VirtualAssistantMainContentComponent implements OnInit {
    * It needs to be a callback function (it will be used as a parameter).
    */
   onClickSaveButton = (): void => {
-    this.dialog.open(LoginModalComponent,{})
+    this.dialog.open(LoginModalComponent, {})
     // TODO implement onClickSaveButton
   }
+
+
+  // Zones tree, get the selected zones and push them to the datashared array (resume)
+
+  checkZones(zoneSelected: any, event: any) {    
+    if (event) {
+      //Adds the selected zone to the array zones in the common service to use it there as parameter
+     this.zonesSelected.push(zoneSelected.zoneName);
+    } else {
+      //removes the zone if it is already in the common service array
+      this.zonesSelected.splice(this.dataShared.indexOf(zoneSelected), 1);
+    }
+  }
+
+
 
 }
 

--- a/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/virtual-assistant-main-content.module.ts
+++ b/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/virtual-assistant-main-content.module.ts
@@ -17,11 +17,12 @@ import { BabcnComponentsModule } from 'src/app/shared/components/babcn-component
 
 
 
+
 @NgModule({
   declarations: [
     VirtualAssistantMainContentComponent,
     ResumeDialogComponent,
-    SaveDialogComponent
+    SaveDialogComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/virtual-assistant-main-content.module.ts
+++ b/src/app/features/virtual-assistant/page-contents/virtual-assistant-main-content/virtual-assistant-main-content.module.ts
@@ -6,6 +6,7 @@ import { I18TranslateModule } from 'src/app/shared/translate/i18-translate.modul
 
 // MATERIAL
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatGridListModule } from '@angular/material/grid-list';
 
@@ -27,6 +28,7 @@ import { BabcnComponentsModule } from 'src/app/shared/components/babcn-component
 
     // MATERIAL
     MatButtonModule,
+    MatCheckboxModule,
     MatDialogModule,
     MatGridListModule,
 

--- a/src/app/features/virtual-assistant/services/virtual-assistant-categories.service.ts
+++ b/src/app/features/virtual-assistant/services/virtual-assistant-categories.service.ts
@@ -37,7 +37,12 @@ export class VirtualAssisstantCategoriesService {
                         title: 'pages.business-assistant.section1.subcat1',
                         items: [
                             { item: 'pages.business-assistant.section1.s1-item1' },
-                            { item: 'pages.business-assistant.section1.s1-item2' }
+                        ]
+                    },
+                    {
+                        title: 'pages.business-assistant.section1.subcat2',
+                        items: [
+                            { item: 'pages.business-assistant.section1.s1-item2' },
                         ]
                     },
                 ]

--- a/src/app/shared/components/mapbox/mapbox.component.ts
+++ b/src/app/shared/components/mapbox/mapbox.component.ts
@@ -210,7 +210,7 @@ export class MapboxComponent implements AfterViewInit {
     
     }
 
-    if(!valid) console.error('ERROR - incorrect coordinates format - ' + business.name + '');    
+    if(!valid) console.log('ERROR - incorrect coordinates format - ' + business.name + '');    
 
     return valid
   }

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -108,8 +108,9 @@
             "section1": {
                 "title": "1. Anàlisi del Sector",
                 "subcat1": "Catàleg de serveis i productes per emprendre",
+                "subcat2": "Ubicació",
                 "s1-item1": "Classificació catalana d'activitats econòmiques",
-                "s1-item2": "Ubicació"
+                "s1-item2": "Veure districtes"
             },
             "section2": {
                 "title": "2. Anàlisi d'hàbits de consum",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -108,8 +108,9 @@
             "section1": {
                 "title": "1. Industry Analysis",
                 "subcat1": "Catalog of services and products to undertake",
+                "subcat2": "Location",
                 "s1-item1": "Catalan classification of economic activities",
-                "s1-item2": "Location"
+                "s1-item2": "View districts"
             },
             "section2": {
                 "title": "2. Analysis of consumption habits",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -108,8 +108,9 @@
             "section1": {
                 "title": "1. Análisis del Sector",
                 "subcat1": "Catálogo de servicios y productos para emprender",
+                "subcat2": "Ubicación",
                 "s1-item1": "Clasificación catalana de actividaes económicas",
-                "s1-item2": "Ubicación"
+                "s1-item2": "Ver distritos"
             },
 
             "section2": {


### PR DESCRIPTION
#274 Mostrado de distritos Asistente virtual: 

- Añadido en 1. Análisis del sector, el sub-folder "ubicación" y en un nivel inferior "ver distritos". 
- Al hacer click en Ver distritos se muestran los distritos en panel derecho.
- Los distritos son seleccionables a través de un checkbox, la selección se guarda en memoria.
- Al clickar en el botón "Ver resumen", emerge una ventana de diálogo con los distritos seleccionados. 